### PR TITLE
Bottom Drawer UI after the User Inputs Origin and Destination

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "0BSD",
       "dependencies": {
         "@expo/metro-runtime": "~4.0.1",
+        "@expo/vector-icons": "^14.0.4",
         "@fortawesome/free-solid-svg-icons": "^6.7.2",
         "@fortawesome/react-native-fontawesome": "^0.3.2",
         "@mapbox/polyline": "^1.2.1",
@@ -4621,15 +4622,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@react-native/gradle-plugin": {
-      "version": "0.77.1",
-      "resolved": "https://registry.npmjs.org/@react-native/gradle-plugin/-/gradle-plugin-0.77.1.tgz",
-      "integrity": "sha512-QNuNMWH0CeC+PYrAXiuUIBbwdeGJ3fZpQM03vdG3tKdk66cVSFvxLh60P0w5kRHN7UFBg2FAcYx5eQ/IdcAntg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/@react-native/js-polyfills": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@expo/metro-runtime": "~4.0.1",
+    "@expo/vector-icons": "^14.0.4",
     "@fortawesome/free-solid-svg-icons": "^6.7.2",
     "@fortawesome/react-native-fontawesome": "^0.3.2",
     "@mapbox/polyline": "^1.2.1",

--- a/src/components/BottomDrawer.tsx
+++ b/src/components/BottomDrawer.tsx
@@ -7,9 +7,11 @@ import {
   Animated,
   PanResponderGestureState,
   Text,
+  TouchableOpacity
 } from "react-native";
 import SearchBars from "./SearchBars";
 import { useCoords } from "../data/CoordsContext";
+import { Ionicons } from "@expo/vector-icons";
 
 
 const { height, width } = Dimensions.get("window");
@@ -24,9 +26,10 @@ function BottomDrawer({
   children: ReactNode;
   drawerHeight: Animated.Value;
 }) {
-  const { routeData: routeCoordinates } = useCoords();
 
+  const { routeData: routeCoordinates } = useCoords();
   const [htmlInstructions, setHtmlInstructions] = useState<string[]>([]);
+  const [selectedMode, setSelectedMode] = useState("walk"); // Default to walking
 
   useEffect(() => {
     console.log("routeCoordinates changed:", routeCoordinates);
@@ -82,17 +85,57 @@ function BottomDrawer({
     })
   ).current;
 
+  const transportModes = [
+    { mode: "car", icon: "car-outline", label: "Driving", time: "12 min" },
+    { mode: "bus", icon: "bus-outline", label: "Transit", time: "20 min" },
+    { mode: "walk", icon: "walk-outline", label: "Walking", time: "35 min" },
+    { mode: "bike", icon: "bicycle-outline", label: "Cycling", time: "18 min" },
+  ];
+
   return (
     <Animated.View style={[styles.container, { height: drawerHeight }]}>
       <View {...panResponder.panHandlers} style={styles.dragHandle}>
         <View style={styles.dragIndicator} />
         <SearchBars />
-        {htmlInstructions.length > 0 &&
-          htmlInstructions.map((instruction, index) => (
-            <Text key={index} >
-              {instruction}
-            </Text>
-          ))}
+        {htmlInstructions.length > 0 && (
+          <>
+            {/* Selected Transport Mode Title */}
+            <View style={styles.selectedModeContainer}>
+              <Text style={styles.selectedModeText}>
+                {transportModes.find((t) => t.mode === selectedMode)?.label}
+              </Text>
+            </View>
+  
+            {/* Transport Buttons with Time Estimates */}
+            <View style={styles.transportButtonContainer}>
+              {transportModes.map(({ mode, icon, time }) => (
+                <TouchableOpacity
+                  key={mode}
+                  style={[
+                    styles.transportButton,
+                  ]}
+                  onPress={() => setSelectedMode(mode)}
+                >
+                  <View style={styles.transportButtonContent}>
+                    <Ionicons
+                      name={icon as keyof typeof Ionicons.glyphMap}
+                      size={24}
+                      color={selectedMode === mode ? "#912338" : "black"}
+                    />
+                    <Text style={[styles.timeText, { color: selectedMode === mode ? "#912338" : "black" }]}>{time}</Text>
+                  </View>
+                </TouchableOpacity>
+              ))}
+            </View>
+  
+            {/* Instructions */}
+            {htmlInstructions.map((instruction, index) => (
+              <View key={index} style={styles.instructionContainer}>
+                <Text>{instruction}</Text>
+              </View>
+            ))}
+          </>
+        )}
       </View>
       <View style={styles.contentContainer}>{children}</View>
     </Animated.View>
@@ -123,6 +166,44 @@ const styles = StyleSheet.create({
   contentContainer: {
     flex: 1,
     padding: 16,
+  },
+  transportButtonContainer: {
+    flexDirection: "row",
+    justifyContent: "space-around",
+    alignItems: "center",
+    width: "100%",
+    paddingHorizontal: 20,
+    borderBottomWidth: 1,
+    borderBottomColor: "#ddd",
+  },
+  transportButton: {
+    alignItems: "center",
+    padding: 10,
+    borderRadius: 8,
+  },
+  instructionContainer: {
+    padding: 10,
+    borderBottomWidth: 1,
+    borderBottomColor: "#ddd",
+  },
+  selectedModeContainer: {
+    width: "100%",
+    alignItems: "flex-start",
+    paddingHorizontal: 20,
+  },
+  selectedModeText: {
+    fontSize: 18,
+    fontWeight: "bold",
+    textAlign: "left",
+    marginVertical: 5,
+  },
+  transportButtonContent: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 6, 
+  },
+  timeText: {
+    fontSize: 12,
   },
 });
 

--- a/src/components/BottomDrawer.tsx
+++ b/src/components/BottomDrawer.tsx
@@ -11,8 +11,6 @@ import {
 } from "react-native";
 import SearchBars from "./SearchBars";
 import { useCoords } from "../data/CoordsContext";
-import { Ionicons } from "@expo/vector-icons";
-
 
 const { height, width } = Dimensions.get("window");
 const COLLAPSED_HEIGHT = height * 0.1;
@@ -29,7 +27,6 @@ function BottomDrawer({
 
   const { routeData: routeCoordinates } = useCoords();
   const [htmlInstructions, setHtmlInstructions] = useState<string[]>([]);
-  const [selectedMode, setSelectedMode] = useState("walk"); // Default to walking
 
   useEffect(() => {
     console.log("routeCoordinates changed:", routeCoordinates);
@@ -85,57 +82,17 @@ function BottomDrawer({
     })
   ).current;
 
-  const transportModes = [
-    { mode: "car", icon: "car-outline", label: "Driving", time: "12 min" },
-    { mode: "bus", icon: "bus-outline", label: "Transit", time: "20 min" },
-    { mode: "walk", icon: "walk-outline", label: "Walking", time: "35 min" },
-    { mode: "bike", icon: "bicycle-outline", label: "Cycling", time: "18 min" },
-  ];
-
   return (
     <Animated.View style={[styles.container, { height: drawerHeight }]}>
       <View {...panResponder.panHandlers} style={styles.dragHandle}>
         <View style={styles.dragIndicator} />
         <SearchBars />
-        {htmlInstructions.length > 0 && (
-          <>
-            {/* Selected Transport Mode Title */}
-            <View style={styles.selectedModeContainer}>
-              <Text style={styles.selectedModeText}>
-                {transportModes.find((t) => t.mode === selectedMode)?.label}
-              </Text>
-            </View>
-  
-            {/* Transport Buttons with Time Estimates */}
-            <View style={styles.transportButtonContainer}>
-              {transportModes.map(({ mode, icon, time }) => (
-                <TouchableOpacity
-                  key={mode}
-                  style={[
-                    styles.transportButton,
-                  ]}
-                  onPress={() => setSelectedMode(mode)}
-                >
-                  <View style={styles.transportButtonContent}>
-                    <Ionicons
-                      name={icon as keyof typeof Ionicons.glyphMap}
-                      size={24}
-                      color={selectedMode === mode ? "#912338" : "black"}
-                    />
-                    <Text style={[styles.timeText, { color: selectedMode === mode ? "#912338" : "black" }]}>{time}</Text>
-                  </View>
-                </TouchableOpacity>
-              ))}
-            </View>
-  
-            {/* Instructions */}
-            {htmlInstructions.map((instruction, index) => (
-              <View key={index} style={styles.instructionContainer}>
-                <Text>{instruction}</Text>
-              </View>
-            ))}
-          </>
-        )}
+        {htmlInstructions.length > 0 &&
+          htmlInstructions.map((instruction, index) => (
+            <Text key={index} >
+              {instruction}
+            </Text>
+          ))}
       </View>
       <View style={styles.contentContainer}>{children}</View>
     </Animated.View>
@@ -166,44 +123,6 @@ const styles = StyleSheet.create({
   contentContainer: {
     flex: 1,
     padding: 16,
-  },
-  transportButtonContainer: {
-    flexDirection: "row",
-    justifyContent: "space-around",
-    alignItems: "center",
-    width: "100%",
-    paddingHorizontal: 20,
-    borderBottomWidth: 1,
-    borderBottomColor: "#ddd",
-  },
-  transportButton: {
-    alignItems: "center",
-    padding: 10,
-    borderRadius: 8,
-  },
-  instructionContainer: {
-    padding: 10,
-    borderBottomWidth: 1,
-    borderBottomColor: "#ddd",
-  },
-  selectedModeContainer: {
-    width: "100%",
-    alignItems: "flex-start",
-    paddingHorizontal: 20,
-  },
-  selectedModeText: {
-    fontSize: 18,
-    fontWeight: "bold",
-    textAlign: "left",
-    marginVertical: 5,
-  },
-  transportButtonContent: {
-    flexDirection: "row",
-    alignItems: "center",
-    gap: 6, 
-  },
-  timeText: {
-    fontSize: 12,
   },
 });
 

--- a/src/components/BuildingCoordinates.tsx
+++ b/src/components/BuildingCoordinates.tsx
@@ -2,6 +2,7 @@ import React, { useMemo } from 'react';
 import Mapbox from '@rnmapbox/maps';
 import * as turf from '@turf/turf';
 import { buildingFeatures } from '../data/buildingFeatures.ts'
+import { useCoords } from "../data/CoordsContext";
 
 interface HighlightBuildingProps {
   userCoordinates: [number, number] | null;
@@ -31,6 +32,8 @@ const fixedBuildingFeatures = buildingFeatures.map((feature) => {
 });
 
 export const HighlightBuilding = ({ userCoordinates }: HighlightBuildingProps) => {
+  const { setIsInsideBuilding } = useCoords();
+
   if (!userCoordinates) {
     return null;
   }
@@ -47,6 +50,9 @@ export const HighlightBuilding = ({ userCoordinates }: HighlightBuildingProps) =
       );
     });
   }, [swappedUserCoordinates]);
+
+  // Update the context state whenever user location changes
+  setIsInsideBuilding(!!highlightedBuilding);
 
   return (
     <>
@@ -65,7 +71,7 @@ export const HighlightBuilding = ({ userCoordinates }: HighlightBuildingProps) =
           style={{
             fillExtrusionColor: ['get', 'color'],
             fillExtrusionHeight: ['get', 'height'],
-            fillExtrusionOpacity: 0.3, 
+            fillExtrusionOpacity: 0.3,
           }}
         />
       </Mapbox.ShapeSource>

--- a/src/components/SearchBars.tsx
+++ b/src/components/SearchBars.tsx
@@ -1,9 +1,11 @@
 // SearchBars.tsx
 import React, { useState, useCallback } from 'react';
-import { View, StyleSheet } from 'react-native';
+import { View, StyleSheet, Text, TouchableOpacity } from 'react-native';
 import SearchBar from './SearchBar';
 import getDirections from './Route';
 import { useCoords } from '../data/CoordsContext';
+import { Ionicons } from "@expo/vector-icons";
+import Entypo from "@expo/vector-icons/Entypo";
 
 const SearchBars: React.FC = () => {
     const { setRouteData } = useCoords();
@@ -11,6 +13,13 @@ const SearchBars: React.FC = () => {
     const [destination, setDestination] = useState('');
     const [originCoords, setOriginCoords] = useState<any>(null);
     const [destinationCoords, setDestinationCoords] = useState<any>(null);
+    const [transportModes, setTransportModes] = useState([
+        { mode: "car", icon: "car-outline", label: "Driving", time: "0" },
+        { mode: "bus", icon: "bus-outline", label: "Transit", time: "0" },
+        { mode: "walk", icon: "walk-outline", label: "Walking", time: "0" },
+        { mode: "bike", icon: "bicycle-outline", label: "Cycling", time: "0" },
+    ]);  
+    const [selectedMode, setSelectedMode] = useState("walk");
 
     const handleOriginSelect = useCallback(async (selectedOrigin: string, coords: any) => {
         setOrigin(selectedOrigin);
@@ -70,6 +79,75 @@ const SearchBars: React.FC = () => {
                 onSelect={handleDestinationSelect}
                 setCoords={setDestinationCoords}
             />
+        
+            {origin.length > 0 && destination.length > 0 && (
+                <>
+                    {/* Selected Transport Mode Title */}
+                    <View style={styles.selectedModeContainer}>
+                        <Text style={styles.selectedModeText}>
+                            {transportModes.find((t) => t.mode === selectedMode)?.label}
+                        </Text>
+                    </View>
+              
+                    {/* Transport Buttons with Time Estimates */}
+                    <View style={styles.transportButtonContainer}>
+                        {transportModes.map(({ mode, icon, time }) => (
+                            <TouchableOpacity
+                                key={mode}
+                                style={styles.transportButton}
+                                onPress={() => setSelectedMode(mode)}
+                            >
+                                <View style={styles.transportButtonContent}>
+                                    <Ionicons
+                                        name={icon as keyof typeof Ionicons.glyphMap}
+                                        size={24}
+                                        color={selectedMode === mode ? "#912338" : "black"}
+                                    />
+                                    <Text style={[styles.timeText, { color: selectedMode === mode ? "#912338" : "black" }]}>
+                                        {time} min
+                                    </Text>
+                                </View>
+                            </TouchableOpacity>
+                        ))}
+                    </View>
+
+                    {/* Total Time, Start Button, and Floor/Outside View Button */}
+                    <View style={styles.timeAndButtonsContainer}>
+                        {/* Time Container */}
+                        <View style={styles.timeContainer}>
+                            <Text style={styles.timeValue}>
+                                {transportModes.find((t) => t.mode === selectedMode)?.time}
+                            </Text>
+                            <Text style={styles.timeUnit}>min</Text>
+                        </View>
+
+                        {/* Buttons Container */}
+                        <View style={styles.buttonsContainer}>
+                        <TouchableOpacity style={[styles.button, { backgroundColor: "#912338" }]}>
+                            <View style={styles.buttonContent}>
+                                <Entypo name="direction" size={20} color="white" />
+                                <Text style={[styles.buttonText, { color: "white"}]}>Start</Text>
+                            </View>
+                        </TouchableOpacity>
+
+                        <TouchableOpacity style={[styles.button, { backgroundColor: "#ddd" }]}>
+                            <View style={styles.buttonContent}>
+                                <Entypo name="location" size={20} color="grey" />
+                                <Text style={[styles.buttonText, { color: "grey"}]}>Floor View</Text>
+                            </View>
+                        </TouchableOpacity>
+
+                            {/* When implementing floor plans, switch between floor and outside view !!!
+                            <TouchableOpacity style={styles.button}>
+                                <View style={styles.buttonContent}>
+                                    <Entypo name="tree" size={20} color="black" />
+                                    <Text style={styles.buttonText}>Outside View</Text>
+                                </View>
+                            </TouchableOpacity> */}
+                        </View>
+                    </View>
+                </>
+            )}
         </View>
     );
 };
@@ -80,6 +158,84 @@ const styles = StyleSheet.create({
         paddingHorizontal: 16,
         paddingBottom: 10,
     },
+    transportButtonContainer: {
+        flexDirection: "row",
+        justifyContent: "space-around",
+        alignItems: "center",
+        width: "100%",
+        paddingHorizontal: 20,
+        borderBottomWidth: 1,
+        borderBottomColor: "#ddd",
+      },
+      transportButton: {
+        alignItems: "center",
+        padding: 10,
+        borderRadius: 8,
+      },
+      instructionContainer: {
+        padding: 10,
+        borderBottomWidth: 1,
+        borderBottomColor: "#ddd",
+      },
+      selectedModeContainer: {
+        width: "100%",
+        alignItems: "flex-start",
+        paddingHorizontal: 20,
+      },
+      selectedModeText: {
+        fontSize: 18,
+        fontWeight: "bold",
+        textAlign: "left",
+        marginVertical: 5,
+      },
+      transportButtonContent: {
+        flexDirection: "row",
+        alignItems: "center",
+        gap: 6, 
+      },
+      timeText: {
+        fontSize: 12,
+      },
+      timeAndButtonsContainer: {
+        flexDirection: "row",
+        alignItems: "center", 
+        justifyContent: "space-between", 
+        paddingHorizontal: 30,
+        paddingVertical: 20,
+      },
+      timeContainer: {
+        alignItems: "center",
+        marginRight: 10,
+      },
+      timeValue: {
+        fontSize: 18,
+        fontWeight: "bold",
+      },
+      timeUnit: {
+        fontSize: 14,
+        color: "#666",
+      },
+      buttonsContainer: {
+        flexDirection: "row",
+        gap: 30,
+      },
+      button: {
+        paddingVertical: 8, 
+        paddingHorizontal: 15,
+        borderRadius: 25,
+        flexDirection: "row",
+        alignItems: "center",
+        justifyContent: "center",
+    },    
+      buttonContent: {
+        flexDirection: "row", 
+        alignItems: "center",
+        gap: 6,
+    },
+    buttonText: {
+        fontSize: 15,
+        fontWeight: "500",
+    },    
 });
 
 export default SearchBars;

--- a/src/components/SearchBars.tsx
+++ b/src/components/SearchBars.tsx
@@ -131,7 +131,17 @@ const SearchBars: React.FC = () => {
                             </View>
                         </TouchableOpacity>
 
-                        <TouchableOpacity style={[styles.button, { backgroundColor: isInsideBuilding ? "white" : "#ddd" }, { borderColor: isInsideBuilding ? "#912338" : "grey" }]}>
+                        <TouchableOpacity 
+                            style={[
+                                styles.button, 
+                                { 
+                                    backgroundColor: isInsideBuilding ? "white" : "#ddd", 
+                                    borderColor: isInsideBuilding ? "#912338" : "grey",
+                                    opacity: isInsideBuilding ? 1 : 0.5
+                                }
+                            ]}
+                            disabled={!isInsideBuilding} // Disable button when user is outside
+                        >
                             <View style={styles.buttonContent}>
                                 <Entypo name="location" size={20} color={isInsideBuilding ? "#912338" : "grey"} />
                                 <Text style={[styles.buttonText, { color: isInsideBuilding ? "#912338" : "grey"}]}>Floor View</Text>

--- a/src/components/SearchBars.tsx
+++ b/src/components/SearchBars.tsx
@@ -14,12 +14,13 @@ const SearchBars: React.FC = () => {
     const [originCoords, setOriginCoords] = useState<any>(null);
     const [destinationCoords, setDestinationCoords] = useState<any>(null);
     const [transportModes, setTransportModes] = useState([
-        { mode: "car", icon: "car-outline", label: "Driving", time: "0" },
-        { mode: "bus", icon: "bus-outline", label: "Transit", time: "0" },
-        { mode: "walk", icon: "walk-outline", label: "Walking", time: "0" },
-        { mode: "bike", icon: "bicycle-outline", label: "Cycling", time: "0" },
+        { mode: "car", icon: "car-outline", label: "Drive", time: "0" },
+        { mode: "publicTransport", icon: "bus-outline", label: "Public Transport", time: "0" },
+        { mode: "walk", icon: "walk-outline", label: "Walk", time: "0" },
+        { mode: "bike", icon: "bicycle-outline", label: "Bicycle", time: "0" },
     ]);  
     const [selectedMode, setSelectedMode] = useState("walk");
+    const { isInsideBuilding } = useCoords();
 
     const handleOriginSelect = useCallback(async (selectedOrigin: string, coords: any) => {
         setOrigin(selectedOrigin);
@@ -123,17 +124,17 @@ const SearchBars: React.FC = () => {
 
                         {/* Buttons Container */}
                         <View style={styles.buttonsContainer}>
-                        <TouchableOpacity style={[styles.button, { backgroundColor: "#912338" }]}>
+                        <TouchableOpacity style={[styles.button, { backgroundColor: "#912338" }, { borderColor: "#912338" }]}>
                             <View style={styles.buttonContent}>
                                 <Entypo name="direction" size={20} color="white" />
                                 <Text style={[styles.buttonText, { color: "white"}]}>Start</Text>
                             </View>
                         </TouchableOpacity>
 
-                        <TouchableOpacity style={[styles.button, { backgroundColor: "#ddd" }]}>
+                        <TouchableOpacity style={[styles.button, { backgroundColor: isInsideBuilding ? "white" : "#ddd" }, { borderColor: isInsideBuilding ? "#912338" : "grey" }]}>
                             <View style={styles.buttonContent}>
-                                <Entypo name="location" size={20} color="grey" />
-                                <Text style={[styles.buttonText, { color: "grey"}]}>Floor View</Text>
+                                <Entypo name="location" size={20} color={isInsideBuilding ? "#912338" : "grey"} />
+                                <Text style={[styles.buttonText, { color: isInsideBuilding ? "#912338" : "grey"}]}>Floor View</Text>
                             </View>
                         </TouchableOpacity>
 
@@ -220,12 +221,13 @@ const styles = StyleSheet.create({
         gap: 30,
       },
       button: {
-        paddingVertical: 8, 
+        paddingVertical: 7, 
         paddingHorizontal: 15,
         borderRadius: 25,
         flexDirection: "row",
         alignItems: "center",
         justifyContent: "center",
+        borderWidth: 1,
     },    
       buttonContent: {
         flexDirection: "row", 

--- a/src/data/CoordsContext.tsx
+++ b/src/data/CoordsContext.tsx
@@ -1,11 +1,5 @@
 import React, { createContext, useState, useContext } from 'react';
-
-interface CoordsContextType {
-    routeData: any;
-    setRouteData: (data: any) => void;
-    isInsideBuilding: boolean;
-    setIsInsideBuilding: (inside: boolean) => void;
-}
+import { CoordsContextType } from '../interfaces/CoordsContextType';
 
 export const CoordsContext = createContext<CoordsContextType>({
     routeData: null,

--- a/src/data/CoordsContext.tsx
+++ b/src/data/CoordsContext.tsx
@@ -1,25 +1,29 @@
-
 import React, { createContext, useState, useContext } from 'react';
-
 
 interface CoordsContextType {
     routeData: any;
     setRouteData: (data: any) => void;
+    isInsideBuilding: boolean;
+    setIsInsideBuilding: (inside: boolean) => void;
 }
 
 export const CoordsContext = createContext<CoordsContextType>({
     routeData: null,
-    setRouteData: () => { }
+    setRouteData: () => {},
+    isInsideBuilding: false,
+    setIsInsideBuilding: () => {}
 });
 
 export const CoordsProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
-
     const [routeData, setRouteData] = useState<any>(null);
+    const [isInsideBuilding, setIsInsideBuilding] = useState<boolean>(false);
 
     return (
         <CoordsContext.Provider value={{
             routeData,
-            setRouteData
+            setRouteData,
+            isInsideBuilding,
+            setIsInsideBuilding
         }}>
             {children}
         </CoordsContext.Provider>

--- a/src/interfaces/CoordsContextType.ts
+++ b/src/interfaces/CoordsContextType.ts
@@ -1,0 +1,6 @@
+export interface CoordsContextType {
+    routeData: any;
+    setRouteData: (data: any) => void;
+    isInsideBuilding: boolean;
+    setIsInsideBuilding: (inside: boolean) => void;
+}


### PR DESCRIPTION
## Description
When the user inputs the origin and destination addresses, the bottom drawer displays buttons to switch transportation modes and the times for each. A _Start_ and _Floor View_ buttons are added, but don't do anything yet. The  _Floor View_ button is unclickable when the user is outside and becomes clickable when the user is inside of a Concordia building. 

## Related Issue
Closes #130 

## Changes Made

- Added a global variable to _CoordsContext.tsx_ to know if the user is inside a Concordia building at all times.
- Added Transportation modes, times for each mode, _Start_ button, and a _Floor View_ button to the bottom drawer.

## Checklist
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly

## Screenshots
<img src="https://github.com/user-attachments/assets/bd189532-c60c-4746-be3c-ee6feb507eb9" width="300">
<img src="https://github.com/user-attachments/assets/4935d5d1-5903-45dd-a11b-f8f2f7b275dc" width="300">
<img src="https://github.com/user-attachments/assets/0f91bae4-e3a2-4ba2-9e92-5e5918482586" width="300">
<img src="https://github.com/user-attachments/assets/4915398c-fa43-41cf-b134-054b1c30bc1c" width="300">

## Additional Notes
The backend isn't implemented yet, meaning that all buttons don't output anything, nor are the times accurate.
