### PR TITLE
Fixed Floor View bug

### DIFF
--- a/src/components/SearchBars.tsx
+++ b/src/components/SearchBars.tsx
@@ -107,6 +107,7 @@ const SearchBars: React.FC<SearchBarProps> = ({ inputDestination }) => {
         setDestination("");
         setDestinationCoords(null);
         setRouteData(null);
+        setInFloorView(false);
     }, [setRouteData]);
 
     useEffect(() => {


### PR DESCRIPTION
## Description
When in _Floor View_ and the _clear destination_ button is clicked, the screen goes back to the default _Home Screen_.

## Related Issue
Closes #197 

## Changes Made
- Inside _handleClearDestination_, the variable _inFloorView_ is set to false

## Checklist
- [ ] I have performed a self-review of my code
- [ ] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly

## Screenshots
Before clearing the destination search bar while in _Floor View_:
![image](https://github.com/user-attachments/assets/6dc5275d-40aa-4e94-b9a0-3bd117d93aca)

After clearing the destination search bar while in _Floor View_:
![image](https://github.com/user-attachments/assets/1137d778-51b4-4bf8-ac13-4440afa4f6fe)

## Additional Notes
N/A
