### PR TITLE
Added a difference colour outline for walking and transit paths

### DIFF
--- a/src/components/SearchBars.tsx
+++ b/src/components/SearchBars.tsx
@@ -9,6 +9,7 @@ import { Ionicons } from "@expo/vector-icons";
 import Entypo from "@expo/vector-icons/Entypo";
 import { SearchBarsStyle } from '../styles/SearchBarsStyle';
 import ShuttleBusTransit from './ShuttleBusTransit';
+import { color } from '@rneui/base';
 
 interface SearchBarProps {
     inputDestination: string;
@@ -57,10 +58,10 @@ const SearchBars: React.FC<SearchBarProps> = ({ inputDestination }) => {
     const [originCoords, setOriginCoords] = useState<any>(null);
     const [destinationCoords, setDestinationCoords] = useState<any>(null);
     const transportModes = [
-        { mode: "driving", icon: "car-outline", label: "Drive", time: "-" },
-        { mode: "transit", icon: "bus-outline", label: "Public Transport", time: "-" },
-        { mode: "walking", icon: "walk-outline", label: "Walk", time: "-" },
-        { mode: "bicycling", icon: "bicycle-outline", label: "Bicycle", time: "-" },
+        { mode: "driving", icon: "car-outline", label: "Drive", time: "-", color: "#673AB7" },
+        { mode: "transit", icon: "bus-outline", label: "Public Transport", time: "-",color: "#2196F3" },
+        { mode: "walking", icon: "walk-outline", label: "Walk", time: "-",color: "#800000" },
+        { mode: "bicycling", icon: "bicycle-outline", label: "Bicycle", time: "-" ,color: "#4CAF50"},
     ];
     const [selectedMode, setSelectedMode] = useState("driving");
     const { isInsideBuilding } = useCoords();
@@ -166,7 +167,7 @@ const SearchBars: React.FC<SearchBarProps> = ({ inputDestination }) => {
                     </View>
                     {/* Transport Buttons with Time Estimates */}
                     <View style={SearchBarsStyle.transportButtonContainer}>
-                        {transportModes.map(({ mode, icon }) => (
+                        {transportModes.map(({ mode, icon,color }) => (
                             <TouchableOpacity
                                 key={mode}
                                 style={SearchBarsStyle.transportButton}
@@ -177,7 +178,7 @@ const SearchBars: React.FC<SearchBarProps> = ({ inputDestination }) => {
                                     <Ionicons
                                         name={icon as keyof typeof Ionicons.glyphMap}
                                         size={24}
-                                        color={selectedMode === mode ? "#912338" : "black"}
+                                        color={selectedMode === mode ? color : "black"}
                                     />
                                     {selectedMode === mode}
                     

--- a/src/interfaces/routeOutline.ts
+++ b/src/interfaces/routeOutline.ts
@@ -1,0 +1,10 @@
+
+interface Coordinate {
+    latitude: number;
+    longitude: number;
+}
+
+interface RouteSegment {
+    mode: 'WALKING' | 'TRANSIT' | 'DRIVING' | 'BICYCLING';
+    coordinates: Coordinate[];
+}

--- a/tests/MapComponent.test.tsx
+++ b/tests/MapComponent.test.tsx
@@ -1,167 +1,167 @@
-// Mock all dependencies before imports
-jest.mock('@rnmapbox/maps', () => {
-  const React = require('react');
-  return {
-    MapView: React.forwardRef((props, ref) => {
-      // Call onDidFinishLoadingMap if provided
-      if (props.onDidFinishLoadingMap) {
-        setTimeout(props.onDidFinishLoadingMap, 0);
-      }
-      return null;
-    }),
-    Camera: jest.fn().mockImplementation(() => null),
-    PointAnnotation: jest.fn().mockImplementation(() => null),
-    ShapeSource: jest.fn().mockImplementation(() => null),
-    LineLayer: jest.fn().mockImplementation(() => null),
-    setAccessToken: jest.fn(),
-  };
-});
+// // Mock all dependencies before imports
+// jest.mock('@rnmapbox/maps', () => {
+//   const React = require('react');
+//   return {
+//     MapView: React.forwardRef((props, ref) => {
+//       // Call onDidFinishLoadingMap if provided
+//       if (props.onDidFinishLoadingMap) {
+//         setTimeout(props.onDidFinishLoadingMap, 0);
+//       }
+//       return null;
+//     }),
+//     Camera: jest.fn().mockImplementation(() => null),
+//     PointAnnotation: jest.fn().mockImplementation(() => null),
+//     ShapeSource: jest.fn().mockImplementation(() => null),
+//     LineLayer: jest.fn().mockImplementation(() => null),
+//     setAccessToken: jest.fn(),
+//   };
+// });
 
-jest.mock('@mapbox/polyline', () => ({
-  decode: jest.fn().mockReturnValue([[45.495, -73.577], [45.496, -73.578]]),
-}));
+// jest.mock('@mapbox/polyline', () => ({
+//   decode: jest.fn().mockReturnValue([[45.495, -73.577], [45.496, -73.578]]),
+// }));
 
-jest.mock('expo-location', () => ({
-  requestForegroundPermissionsAsync: jest.fn().mockResolvedValue({ status: 'granted' }),
-  getCurrentPositionAsync: jest.fn().mockResolvedValue({
-    coords: {
-      latitude: 45.495,
-      longitude: -73.577,
-    },
-  }),
-  watchPositionAsync: jest.fn().mockReturnValue(Promise.resolve({ remove: jest.fn() })),
-  Accuracy: { High: 'high' },
-}));
+// jest.mock('expo-location', () => ({
+//   requestForegroundPermissionsAsync: jest.fn().mockResolvedValue({ status: 'granted' }),
+//   getCurrentPositionAsync: jest.fn().mockResolvedValue({
+//     coords: {
+//       latitude: 45.495,
+//       longitude: -73.577,
+//     },
+//   }),
+//   watchPositionAsync: jest.fn().mockReturnValue(Promise.resolve({ remove: jest.fn() })),
+//   Accuracy: { High: 'high' },
+// }));
 
-// Mock all components used by MapComponent
-jest.mock('../src/data/CoordsContext', () => ({
-  useCoords: jest.fn().mockReturnValue({
-    routeData: [],
-    setmyLocationString: jest.fn(),
-    myLocationCoords: null,
-    setMyLocationCoords: jest.fn(),
-  }),
-}));
+// // Mock all components used by MapComponent
+// jest.mock('../src/data/CoordsContext', () => ({
+//   useCoords: jest.fn().mockReturnValue({
+//     routeData: [],
+//     setmyLocationString: jest.fn(),
+//     myLocationCoords: null,
+//     setMyLocationCoords: jest.fn(),
+//   }),
+// }));
 
-jest.mock('../src/data/IndoorContext', () => ({
-  useIndoor: jest.fn().mockReturnValue({
-    inFloorView: false,
-  }),
-}));
+// jest.mock('../src/data/IndoorContext', () => ({
+//   useIndoor: jest.fn().mockReturnValue({
+//     inFloorView: false,
+//   }),
+// }));
 
-jest.mock('../src/components/BuildingCoordinates', () => ({
-  HighlightBuilding: jest.fn().mockImplementation(() => null),
-}));
+// jest.mock('../src/components/BuildingCoordinates', () => ({
+//   HighlightBuilding: jest.fn().mockImplementation(() => null),
+// }));
 
-jest.mock('../src/components/IndoorMap', () => ({
-  HighlightIndoorMap: jest.fn().mockImplementation(() => null),
-}));
+// jest.mock('../src/components/IndoorMap', () => ({
+//   HighlightIndoorMap: jest.fn().mockImplementation(() => null),
+// }));
 
-jest.mock('../src/components/ShuttleBusTracker', () => jest.fn().mockImplementation(() => null));
-jest.mock('../src/components/ToggleButton', () => jest.fn().mockImplementation(() => null));
-jest.mock('../src/components/BuildingInformation', () => jest.fn().mockImplementation(() => null));
+// jest.mock('../src/components/ShuttleBusTracker', () => jest.fn().mockImplementation(() => null));
+// jest.mock('../src/components/ToggleButton', () => jest.fn().mockImplementation(() => null));
+// jest.mock('../src/components/BuildingInformation', () => jest.fn().mockImplementation(() => null));
 
-// Suppress console.log during tests
-const originalConsoleLog = console.log;
-beforeAll(() => {
-  console.log = jest.fn();
-});
+// // Suppress console.log during tests
+// const originalConsoleLog = console.log;
+// beforeAll(() => {
+//   console.log = jest.fn();
+// });
 
-afterAll(() => {
-  console.log = originalConsoleLog;
-});
+// afterAll(() => {
+//   console.log = originalConsoleLog;
+// });
 
-// Now after all mocks are set up, import React and testing libraries
-import React from 'react';
-import { render, waitFor } from '@testing-library/react-native';
-import { Animated } from 'react-native';
-import * as Location from 'expo-location';
-import { useCoords } from '../src/data/CoordsContext';
+// // Now after all mocks are set up, import React and testing libraries
+// import React from 'react';
+// import { render, waitFor } from '@testing-library/react-native';
+// import { Animated } from 'react-native';
+// import * as Location from 'expo-location';
+// import { useCoords } from '../src/data/CoordsContext';
 
-// Import the component to test
-import MapComponent from '../src/components/MapComponent';
+// // Import the component to test
+// import MapComponent from '../src/components/MapComponent';
 
-describe('MapComponent', () => {
-  const mockSetInputDestination = jest.fn();
-  const mockAnimatedValue = new Animated.Value(100);
+// describe('MapComponent', () => {
+//   const mockSetInputDestination = jest.fn();
+//   const mockAnimatedValue = new Animated.Value(100);
   
-  beforeEach(() => {
-    jest.clearAllMocks();
-  });
+//   beforeEach(() => {
+//     jest.clearAllMocks();
+//   });
 
-  test('renders without crashing', () => {
-    render(
-      <MapComponent 
-        drawerHeight={mockAnimatedValue} 
-        setInputDestination={mockSetInputDestination} 
-      />
-    );
-  });
+//   test('renders without crashing', () => {
+//     render(
+//       <MapComponent 
+//         drawerHeight={mockAnimatedValue} 
+//         setInputDestination={mockSetInputDestination} 
+//       />
+//     );
+//   });
 
-  test('requests location permissions on mount', async () => {
-    // First wait for the mocked promises to resolve
-    render(
-      <MapComponent 
-        drawerHeight={mockAnimatedValue} 
-        setInputDestination={mockSetInputDestination} 
-      />
-    );
+//   test('requests location permissions on mount', async () => {
+//     // First wait for the mocked promises to resolve
+//     render(
+//       <MapComponent 
+//         drawerHeight={mockAnimatedValue} 
+//         setInputDestination={mockSetInputDestination} 
+//       />
+//     );
     
-    // Then check if the permissions were requested
-    await waitFor(() => {
-      expect(Location.requestForegroundPermissionsAsync).toHaveBeenCalled();
-      expect(Location.getCurrentPositionAsync).toHaveBeenCalled();
-    });
-  });
+//     // Then check if the permissions were requested
+//     await waitFor(() => {
+//       expect(Location.requestForegroundPermissionsAsync).toHaveBeenCalled();
+//       expect(Location.getCurrentPositionAsync).toHaveBeenCalled();
+//     });
+//   });
 
-  test('handles location permission denial', async () => {
-    // Mock location permission denial
-    Location.requestForegroundPermissionsAsync.mockImplementationOnce(() => 
-      Promise.resolve({ status: 'denied' })
-    );
+//   test('handles location permission denial', async () => {
+//     // Mock location permission denial
+//     Location.requestForegroundPermissionsAsync.mockImplementationOnce(() => 
+//       Promise.resolve({ status: 'denied' })
+//     );
     
-    const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
+//     const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
     
-    render(
-      <MapComponent 
-        drawerHeight={mockAnimatedValue} 
-        setInputDestination={mockSetInputDestination} 
-      />
-    );
+//     render(
+//       <MapComponent 
+//         drawerHeight={mockAnimatedValue} 
+//         setInputDestination={mockSetInputDestination} 
+//       />
+//     );
     
-    await waitFor(() => {
-      expect(consoleWarnSpy).toHaveBeenCalledWith('Permission to access location was denied');
-    });
+//     await waitFor(() => {
+//       expect(consoleWarnSpy).toHaveBeenCalledWith('Permission to access location was denied');
+//     });
     
-    consoleWarnSpy.mockRestore();
-  });
+//     consoleWarnSpy.mockRestore();
+//   });
 
-  test('processes route data when available', async () => {
-    // Setup route data
-    const mockPolyline = require('@mapbox/polyline');
-    const mockRouteData = [{
-      overview_polyline: {
-        points: "mock_polyline_string"
-      }
-    }];
+//   test('processes route data when available', async () => {
+//     // Setup route data
+//     const mockPolyline = require('@mapbox/polyline');
+//     const mockRouteData = [{
+//       overview_polyline: {
+//         points: "mock_polyline_string"
+//       }
+//     }];
     
-    // Mock the useCoords hook to return route data
-    (useCoords as jest.Mock).mockReturnValueOnce({
-      routeData: mockRouteData,
-      setmyLocationString: jest.fn(),
-      myLocationCoords: { latitude: 45.495, longitude: -73.577 },
-      setMyLocationCoords: jest.fn()
-    });
+//     // Mock the useCoords hook to return route data
+//     (useCoords as jest.Mock).mockReturnValueOnce({
+//       routeData: mockRouteData,
+//       setmyLocationString: jest.fn(),
+//       myLocationCoords: { latitude: 45.495, longitude: -73.577 },
+//       setMyLocationCoords: jest.fn()
+//     });
     
-    render(
-      <MapComponent 
-        drawerHeight={mockAnimatedValue} 
-        setInputDestination={mockSetInputDestination} 
-      />
-    );
+//     render(
+//       <MapComponent 
+//         drawerHeight={mockAnimatedValue} 
+//         setInputDestination={mockSetInputDestination} 
+//       />
+//     );
     
-    await waitFor(() => {
-      expect(mockPolyline.decode).toHaveBeenCalledWith("mock_polyline_string");
-    });
-  });
-});
+//     await waitFor(() => {
+//       expect(mockPolyline.decode).toHaveBeenCalledWith("mock_polyline_string");
+//     });
+//   });
+// });

--- a/tests/MapComponent.test.tsx
+++ b/tests/MapComponent.test.tsx
@@ -1,167 +1,167 @@
-// // Mock all dependencies before imports
-// jest.mock('@rnmapbox/maps', () => {
-//   const React = require('react');
-//   return {
-//     MapView: React.forwardRef((props, ref) => {
-//       // Call onDidFinishLoadingMap if provided
-//       if (props.onDidFinishLoadingMap) {
-//         setTimeout(props.onDidFinishLoadingMap, 0);
-//       }
-//       return null;
-//     }),
-//     Camera: jest.fn().mockImplementation(() => null),
-//     PointAnnotation: jest.fn().mockImplementation(() => null),
-//     ShapeSource: jest.fn().mockImplementation(() => null),
-//     LineLayer: jest.fn().mockImplementation(() => null),
-//     setAccessToken: jest.fn(),
-//   };
-// });
+// Mock all dependencies before imports
+jest.mock('@rnmapbox/maps', () => {
+  const React = require('react');
+  return {
+    MapView: React.forwardRef((props, ref) => {
+      // Call onDidFinishLoadingMap if provided
+      if (props.onDidFinishLoadingMap) {
+        setTimeout(props.onDidFinishLoadingMap, 0);
+      }
+      return null;
+    }),
+    Camera: jest.fn().mockImplementation(() => null),
+    PointAnnotation: jest.fn().mockImplementation(() => null),
+    ShapeSource: jest.fn().mockImplementation(() => null),
+    LineLayer: jest.fn().mockImplementation(() => null),
+    setAccessToken: jest.fn(),
+  };
+});
 
-// jest.mock('@mapbox/polyline', () => ({
-//   decode: jest.fn().mockReturnValue([[45.495, -73.577], [45.496, -73.578]]),
-// }));
+jest.mock('@mapbox/polyline', () => ({
+  decode: jest.fn().mockReturnValue([[45.495, -73.577], [45.496, -73.578]]),
+}));
 
-// jest.mock('expo-location', () => ({
-//   requestForegroundPermissionsAsync: jest.fn().mockResolvedValue({ status: 'granted' }),
-//   getCurrentPositionAsync: jest.fn().mockResolvedValue({
-//     coords: {
-//       latitude: 45.495,
-//       longitude: -73.577,
-//     },
-//   }),
-//   watchPositionAsync: jest.fn().mockReturnValue(Promise.resolve({ remove: jest.fn() })),
-//   Accuracy: { High: 'high' },
-// }));
+jest.mock('expo-location', () => ({
+  requestForegroundPermissionsAsync: jest.fn().mockResolvedValue({ status: 'granted' }),
+  getCurrentPositionAsync: jest.fn().mockResolvedValue({
+    coords: {
+      latitude: 45.495,
+      longitude: -73.577,
+    },
+  }),
+  watchPositionAsync: jest.fn().mockReturnValue(Promise.resolve({ remove: jest.fn() })),
+  Accuracy: { High: 'high' },
+}));
 
-// // Mock all components used by MapComponent
-// jest.mock('../src/data/CoordsContext', () => ({
-//   useCoords: jest.fn().mockReturnValue({
-//     routeData: [],
-//     setmyLocationString: jest.fn(),
-//     myLocationCoords: null,
-//     setMyLocationCoords: jest.fn(),
-//   }),
-// }));
+// Mock all components used by MapComponent
+jest.mock('../src/data/CoordsContext', () => ({
+  useCoords: jest.fn().mockReturnValue({
+    routeData: [],
+    setmyLocationString: jest.fn(),
+    myLocationCoords: null,
+    setMyLocationCoords: jest.fn(),
+  }),
+}));
 
-// jest.mock('../src/data/IndoorContext', () => ({
-//   useIndoor: jest.fn().mockReturnValue({
-//     inFloorView: false,
-//   }),
-// }));
+jest.mock('../src/data/IndoorContext', () => ({
+  useIndoor: jest.fn().mockReturnValue({
+    inFloorView: false,
+  }),
+}));
 
-// jest.mock('../src/components/BuildingCoordinates', () => ({
-//   HighlightBuilding: jest.fn().mockImplementation(() => null),
-// }));
+jest.mock('../src/components/BuildingCoordinates', () => ({
+  HighlightBuilding: jest.fn().mockImplementation(() => null),
+}));
 
-// jest.mock('../src/components/IndoorMap', () => ({
-//   HighlightIndoorMap: jest.fn().mockImplementation(() => null),
-// }));
+jest.mock('../src/components/IndoorMap', () => ({
+  HighlightIndoorMap: jest.fn().mockImplementation(() => null),
+}));
 
-// jest.mock('../src/components/ShuttleBusTracker', () => jest.fn().mockImplementation(() => null));
-// jest.mock('../src/components/ToggleButton', () => jest.fn().mockImplementation(() => null));
-// jest.mock('../src/components/BuildingInformation', () => jest.fn().mockImplementation(() => null));
+jest.mock('../src/components/ShuttleBusTracker', () => jest.fn().mockImplementation(() => null));
+jest.mock('../src/components/ToggleButton', () => jest.fn().mockImplementation(() => null));
+jest.mock('../src/components/BuildingInformation', () => jest.fn().mockImplementation(() => null));
 
-// // Suppress console.log during tests
-// const originalConsoleLog = console.log;
-// beforeAll(() => {
-//   console.log = jest.fn();
-// });
+// Suppress console.log during tests
+const originalConsoleLog = console.log;
+beforeAll(() => {
+  console.log = jest.fn();
+});
 
-// afterAll(() => {
-//   console.log = originalConsoleLog;
-// });
+afterAll(() => {
+  console.log = originalConsoleLog;
+});
 
-// // Now after all mocks are set up, import React and testing libraries
-// import React from 'react';
-// import { render, waitFor } from '@testing-library/react-native';
-// import { Animated } from 'react-native';
-// import * as Location from 'expo-location';
-// import { useCoords } from '../src/data/CoordsContext';
+// Now after all mocks are set up, import React and testing libraries
+import React from 'react';
+import { render, waitFor } from '@testing-library/react-native';
+import { Animated } from 'react-native';
+import * as Location from 'expo-location';
+import { useCoords } from '../src/data/CoordsContext';
 
-// // Import the component to test
-// import MapComponent from '../src/components/MapComponent';
+// Import the component to test
+import MapComponent from '../src/components/MapComponent';
 
-// describe('MapComponent', () => {
-//   const mockSetInputDestination = jest.fn();
-//   const mockAnimatedValue = new Animated.Value(100);
+describe('MapComponent', () => {
+  const mockSetInputDestination = jest.fn();
+  const mockAnimatedValue = new Animated.Value(100);
   
-//   beforeEach(() => {
-//     jest.clearAllMocks();
-//   });
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
 
-//   test('renders without crashing', () => {
-//     render(
-//       <MapComponent 
-//         drawerHeight={mockAnimatedValue} 
-//         setInputDestination={mockSetInputDestination} 
-//       />
-//     );
-//   });
+  test('renders without crashing', () => {
+    render(
+      <MapComponent 
+        drawerHeight={mockAnimatedValue} 
+        setInputDestination={mockSetInputDestination} 
+      />
+    );
+  });
 
-//   test('requests location permissions on mount', async () => {
-//     // First wait for the mocked promises to resolve
-//     render(
-//       <MapComponent 
-//         drawerHeight={mockAnimatedValue} 
-//         setInputDestination={mockSetInputDestination} 
-//       />
-//     );
+  test('requests location permissions on mount', async () => {
+    // First wait for the mocked promises to resolve
+    render(
+      <MapComponent 
+        drawerHeight={mockAnimatedValue} 
+        setInputDestination={mockSetInputDestination} 
+      />
+    );
     
-//     // Then check if the permissions were requested
-//     await waitFor(() => {
-//       expect(Location.requestForegroundPermissionsAsync).toHaveBeenCalled();
-//       expect(Location.getCurrentPositionAsync).toHaveBeenCalled();
-//     });
-//   });
+    // Then check if the permissions were requested
+    await waitFor(() => {
+      expect(Location.requestForegroundPermissionsAsync).toHaveBeenCalled();
+      expect(Location.getCurrentPositionAsync).toHaveBeenCalled();
+    });
+  });
 
-//   test('handles location permission denial', async () => {
-//     // Mock location permission denial
-//     Location.requestForegroundPermissionsAsync.mockImplementationOnce(() => 
-//       Promise.resolve({ status: 'denied' })
-//     );
+  test('handles location permission denial', async () => {
+    // Mock location permission denial
+    Location.requestForegroundPermissionsAsync.mockImplementationOnce(() => 
+      Promise.resolve({ status: 'denied' })
+    );
     
-//     const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
+    const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
     
-//     render(
-//       <MapComponent 
-//         drawerHeight={mockAnimatedValue} 
-//         setInputDestination={mockSetInputDestination} 
-//       />
-//     );
+    render(
+      <MapComponent 
+        drawerHeight={mockAnimatedValue} 
+        setInputDestination={mockSetInputDestination} 
+      />
+    );
     
-//     await waitFor(() => {
-//       expect(consoleWarnSpy).toHaveBeenCalledWith('Permission to access location was denied');
-//     });
+    await waitFor(() => {
+      expect(consoleWarnSpy).toHaveBeenCalledWith('Permission to access location was denied');
+    });
     
-//     consoleWarnSpy.mockRestore();
-//   });
+    consoleWarnSpy.mockRestore();
+  });
 
-//   test('processes route data when available', async () => {
-//     // Setup route data
-//     const mockPolyline = require('@mapbox/polyline');
-//     const mockRouteData = [{
-//       overview_polyline: {
-//         points: "mock_polyline_string"
-//       }
-//     }];
+  test('processes route data when available', async () => {
+    // Setup route data
+    const mockPolyline = require('@mapbox/polyline');
+    const mockRouteData = [{
+      overview_polyline: {
+        points: "mock_polyline_string"
+      }
+    }];
     
-//     // Mock the useCoords hook to return route data
-//     (useCoords as jest.Mock).mockReturnValueOnce({
-//       routeData: mockRouteData,
-//       setmyLocationString: jest.fn(),
-//       myLocationCoords: { latitude: 45.495, longitude: -73.577 },
-//       setMyLocationCoords: jest.fn()
-//     });
+    // Mock the useCoords hook to return route data
+    (useCoords as jest.Mock).mockReturnValueOnce({
+      routeData: mockRouteData,
+      setmyLocationString: jest.fn(),
+      myLocationCoords: { latitude: 45.495, longitude: -73.577 },
+      setMyLocationCoords: jest.fn()
+    });
     
-//     render(
-//       <MapComponent 
-//         drawerHeight={mockAnimatedValue} 
-//         setInputDestination={mockSetInputDestination} 
-//       />
-//     );
+    render(
+      <MapComponent 
+        drawerHeight={mockAnimatedValue} 
+        setInputDestination={mockSetInputDestination} 
+      />
+    );
     
-//     await waitFor(() => {
-//       expect(mockPolyline.decode).toHaveBeenCalledWith("mock_polyline_string");
-//     });
-//   });
-// });
+    await waitFor(() => {
+      expect(mockPolyline.decode).toHaveBeenCalledWith("mock_polyline_string");
+    });
+  });
+});


### PR DESCRIPTION
## Description
Implemented distinct color scheme for transportation mode lines in map visualization

## Related Issue
Closes #215

## Changes Made

- Updated color scheme in Mapbox.LineLayer for different transportation modes
- Separated the route outline into different segments when travel mode changes (e.g WALKING to bus stop -> TAKING BUS)
- When clicked a certain transportation mode, colour will change according to its respective route outline colour

## Checklist
- [ ] I have performed a self-review of my code
- [ ] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly

## Screenshots (if applicable)
![image](https://github.com/user-attachments/assets/fecceee5-bb96-46c7-8bdd-1c71781c2fa8)


## Additional Notes
N/A
