### PR TITLE
Fix destination room only bug

### DIFF
--- a/src/components/IndoorNavigation.tsx
+++ b/src/components/IndoorNavigation.tsx
@@ -628,7 +628,6 @@ export const IndoorNavigation: React.FC = () => {
 // Helper component to integrate with your HighlightIndoorMap
 export const NavigationOverlay: React.FC = () => {
   const { inFloorView, indoorFeatures, setOriginRoom, setDestinationRoom } = useIndoor();
-  const { setOriginCoords, setDestinationCoords } = useCoords();
   
   useEffect(() => {
     // When exiting floor view, clear indoor navigation data
@@ -636,15 +635,6 @@ export const NavigationOverlay: React.FC = () => {
       // Clear indoor room selections when exiting floor view
       setOriginRoom(null);
       setDestinationRoom(null);
-    }
-  }, [inFloorView]);
-  
-  useEffect(() => {
-    // When entering indoor navigation mode, clear outdoor navigation data
-    if (inFloorView) {
-      // Clear outdoor coordinates to prevent mixed navigation
-      setOriginCoords(null);
-      setDestinationCoords(null);
     }
   }, [inFloorView]);
 

--- a/src/components/RoomSearchBar.tsx
+++ b/src/components/RoomSearchBar.tsx
@@ -10,7 +10,6 @@ import { fixedBuildingFeatures } from "./BuildingCoordinates";
 import { useCoords } from "../data/CoordsContext";
 import { useFloorSelection } from "./FloorSelector";
 import { RoomInfo } from "../interfaces/RoomInfo"
-import analytics from '@react-native-firebase/analytics';
 import { useIndoor } from "../data/IndoorContext";
 
 interface RoomSearchBarProps {

--- a/src/components/RoomSearchBar.tsx
+++ b/src/components/RoomSearchBar.tsx
@@ -10,6 +10,7 @@ import { fixedBuildingFeatures } from "./BuildingCoordinates";
 import { useCoords } from "../data/CoordsContext";
 import { useFloorSelection } from "./FloorSelector";
 import { RoomInfo } from "../interfaces/RoomInfo"
+import analytics from '@react-native-firebase/analytics';
 import { useIndoor } from "../data/IndoorContext";
 
 interface RoomSearchBarProps {
@@ -192,7 +193,7 @@ export const RoomSearchBar: React.FC<RoomSearchBarProps> = ({
 
         if (floorIndex !== -1) {
             // only change to that floor if inside the building
-            if (highlightedBuilding.properties.id === buildingID) {
+            if (highlightedBuilding && highlightedBuilding.properties.id === buildingID) {
                 handleSelectFloor(floorNameFormat(room.floor));
             }
         };


### PR DESCRIPTION
## Description
Now when you aren't in a Concordia building but you look for a destination room, there is no error.

## Related Issue
Closes #275 

## Changes Made
- Fixed error
- Removed useEffect that was causing bugs when switching locations

## Checklist
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly

## Screenshots
N/A

## Additional Notes
N/A
